### PR TITLE
Fixing typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ square(42, r => {
     // => 1764
 });
 
-// No error, even we don't send the callback function
+// No error, even though we didn't pass the callback function
 square(42);
 ```
 


### PR DESCRIPTION
Fixing a grammar problem inside the example of the file README.md.

If this PR gets merged and labeled **hacktoberfest-accepted** I will be very grateful. 😊
Thank you and have a good day.